### PR TITLE
Adding compile options for C99 mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ if(NOT USB_LIB)
 	  message(FATAL_ERROR "rtlsdr library not found")
 endif()
 
+add_compile_options("-std=c99")
+
 add_library(encoding STATIC hex.c manchester.c)
 add_library(runningavg STATIC runningavg.c)
 add_library(demodulator STATIC demodulator.c)


### PR DESCRIPTION
I was getting the following errors while compiling, seems simple enough to set the mode to C99 instead of going back and declaring `int j;` before every loop. :-D

```
pi@pi:~/subarufobrob/build $ make
Scanning dependencies of target encoding
[  4%] Building C object CMakeFiles/encoding.dir/hex.c.o
[  9%] Building C object CMakeFiles/encoding.dir/manchester.c.o
/home/pi/subarufobrob/manchester.c: In function ‘manchester_decode’:
/home/pi/subarufobrob/manchester.c:32:2: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
  for (int j= 0; j < len; j++)
  ^
```